### PR TITLE
Use frame buffer list instead of the fundamental one

### DIFF
--- a/iflipb.el
+++ b/iflipb.el
@@ -222,7 +222,7 @@ of iflipb-current-buffer-index.")
   "Returns a list of buffer names not matching a filter."
   (iflipb-filter
    (lambda (b) (not (iflipb-match-filter (buffer-name b) filter)))
-   (buffer-list)))
+   (buffer-list (selected-frame))))
 
 (defun iflipb-interesting-buffers ()
   "Returns buffers that should be included in the displayed


### PR DESCRIPTION
Using the fundamental buffer list conflates buffer-visiting activity
across all frames, and makes things more confusing when using multiple
frames to help with context switching.

By using frame buffer lists, visiting buffers in some other frame does
not affect the order in which they are proposed in this frame.