### PR TITLE
Add customization types for defcustom forms missing them.

### DIFF
--- a/iflipb.el
+++ b/iflipb.el
@@ -163,7 +163,7 @@ match."
   :type '(choice
           (regexp :tag "Regexp that describes buffer names to exclude")
           (function :tag "Function that takes a buffer name")
-          (list (string :tag "List of buffers to exclude")))
+          (list (string :tag "Buffer to exclude")))
   :group 'iflipb)
 
 (defcustom iflipb-always-ignore-buffers "^ "
@@ -180,7 +180,7 @@ value match."
   :type '(choice
           (regexp :tag "Regexp that describes buffer names to exclude")
           (function :tag "Function that takes a buffer name")
-          (list (string :tag "List of buffers to exclude")))
+          (list (string :tag "Buffer to always exclude")))
   :group 'iflipb)
 
 (defcustom iflipb-wrap-around nil

--- a/iflipb.el
+++ b/iflipb.el
@@ -160,6 +160,10 @@ buffer name as an argument (a return value of nil from the
 function means include and non-nil means exclude). If the value
 is a list, the filter matches if any of the elements in the value
 match."
+  :type '(choice
+          (regexp :tag "Regexp that describes buffer names to exclude")
+          (function :tag "Function that takes a buffer name")
+          (list (string :tag "List of buffers to exclude")))
   :group 'iflipb)
 
 (defcustom iflipb-always-ignore-buffers "^ "
@@ -173,6 +177,10 @@ will get a buffer name as an argument (a return value of nil from
 the function means include and non-nil means exclude). If the
 value is a list, the filter matches if any of the elements in the
 value match."
+  :type '(choice
+          (regexp :tag "Regexp that describes buffer names to exclude")
+          (function :tag "Function that takes a buffer name")
+          (list (string :tag "List of buffers to exclude")))
   :group 'iflipb)
 
 (defcustom iflipb-wrap-around nil
@@ -180,6 +188,8 @@ value match."
 
 This variable determines whether buffer cycling should wrap
 around when an edge is reached in the buffer list."
+  :type 'boolean
+  :safe #'booleanp
   :group 'iflipb)
 
 (defcustom iflipb-permissive-flip-back nil
@@ -191,6 +201,8 @@ iflipb-*-buffer command in a row. In other words: Running
 `iflipb-previous-buffer' after editing a buffer will act as if
 the current buffer was not visited; it will stay in its original
 place in the buffer list."
+  :type 'boolean
+  :safe #'booleanp
   :group 'iflipb)
 
 (defface iflipb-other-buffer-face
@@ -208,7 +220,9 @@ place in the buffer list."
   "String template for displaying other buffers.
 
 This is the template string that will be applied to a non-current
-buffer name. Use `%s' to refer to the buffer name."
+buffer name. Use `%s' to refer to the buffer name.
+Note: don't enter the surrounding quotes in the input field."
+  :type 'string
   :group 'iflipb)
 
 (defcustom iflipb-current-buffer-template
@@ -216,7 +230,9 @@ buffer name. Use `%s' to refer to the buffer name."
   "String template for displaying the current buffer.
 
 This is the template string that will be applied to the current
-buffer name. Use `%s' to refer to the buffer name."
+buffer name. Use `%s' to refer to the buffer name.
+Note: don't enter the surrounding quotes in the input field."
+  :type 'strings
   :group 'iflipb)
 
 (defcustom iflipb-buffer-list-function


### PR DESCRIPTION
The user I/F for string will change a little because the fields are now typed as strings:
 - it will not be necessary to enter the surrounding double quotes as it was before.
-  However, the data stored in customization file(s) will not change, and the defaults do not change either.

 The commit should be completely backward compatible.
 It just provides extra data input checking protection, and gets rid of the byte-compiler  warning about the lack of type specifications in the forms.