### PR TITLE
Fix byte compiler warning

### DIFF
--- a/iflipb.el
+++ b/iflipb.el
@@ -318,6 +318,7 @@ This is the original order of buffers to the left of
 (defun iflipb-ido-buffer-list ()
   "Ido buffer list for iflipb."
   (require 'ido)
+  (declare-function ido-make-buffer-list "ido")
   (let* ((ido-process-ignore-lists t)
          ido-ignored-list
          ido-ignore-buffers


### PR DESCRIPTION
Only one byte compiler warning about unknown `ido-make-buffer-list` function for a built-in package.  
- No-cost addition of `declare-function` form that evaluates to nil and prevents the byte-compiler warning.